### PR TITLE
Fix a filterMode problem in demo scene

### DIFF
--- a/Scenes/Scripts/HeightmapToTexture.cs
+++ b/Scenes/Scripts/HeightmapToTexture.cs
@@ -61,6 +61,7 @@ public class HeightmapToTexture : MonoBehaviour
                     tex_map.SetPixel(i, j, Color.white);
             }
         }
+        tex_map.filterMode = FilterMode.Point;
         tex_map.Apply();
         mr3.material.mainTexture = tex_map;   
     }


### PR DESCRIPTION
Set texture's filterMode to point. Resolves an issue where filterMode on a generated T2D was default - bilinear