### PR TITLE
Add heightmap package json and asmdefs

### DIFF
--- a/Scripts/Editor/com.js.heightmap.editor.asmdef
+++ b/Scripts/Editor/com.js.heightmap.editor.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "com.js.heightmap.editor",
+    "references": [
+        "GUID:eb058a434e06c494283ca616dd1c0a51"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/Scripts/Editor/com.js.heightmap.editor.asmdef.meta
+++ b/Scripts/Editor/com.js.heightmap.editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0ed2eff66bdd64343885c84009beabd3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.js.heightmap.asmdef
+++ b/com.js.heightmap.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "com.js.heightmap"
+}

--- a/com.js.heightmap.asmdef.meta
+++ b/com.js.heightmap.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eb058a434e06c494283ca616dd1c0a51
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "com.johnasharifi.heightmaplib",
+  "version": "0.1.0",
+  "displayName": "Heightmap Library",
+  "description": "Library for generating 2D arrays of biome and height data",
+  "unity": "2019.1",
+  "unityRelease": "0b5",
+  "author": {
+    "name": "John Sharifi",
+    "email": "johnasharifi@gmail.com",
+    "url": "https://github.com/johnasharifi/HeightmapLibrary"
+  }
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4fadd0ea3fe96e643ad3d93b277b8e60
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
package json had to be made with UTF-8 without BOM / byte-order-mark. Needed asmdefs for package in general, and a single additional asmdef for editor ui scripts which were all in one place